### PR TITLE
✨Support multiple commands in a single alias

### DIFF
--- a/.ubolt.yaml
+++ b/.ubolt.yaml
@@ -4,3 +4,8 @@ lint:
 lint-fix:
   command: npm run lint-fix
   description: Run lint, but fix any findings
+multi:
+  commands:
+    - sleep 1
+    - ls -la
+  description: Do a test with multiple commands

--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ u ubolt-info
 
 If you just type in `ubolt`, or give it an alias not found, it will display all the user & local aliases it can find, based on your current directory.
 
+## Multiple commands
+
+If you want an alias to execute multiple commands, just use `commands:` instead of `command:` in your yaml. For example:
+
+```
+master:
+    commands:
+        - git checkout master
+        - git pull
+    description: Return to master and pull latest
+```
+
+Note that if one of the commands fails, the execution will stop.
+
 ## Naming
 
 I wanted to make a very fast alias command executor, so why not name it after the worlds fastest man?

--- a/bin/ubolt.js
+++ b/bin/ubolt.js
@@ -5,7 +5,7 @@ const pkginfo = require('pkginfo')(module);
 const yaml = require('js-yaml');
 const homedir = require('os').homedir();
 
-const { exec } = require('child_process');
+const { execSync } = require('child_process');
 
 const local = localCommands();
 const user = userCommands();
@@ -13,16 +13,21 @@ const commands = { ...user, ...local };
 const command = process.argv.length > 2 ? commands[process.argv[2]] : null;
 
 if (command != null) {
-  try {
-    var commandProcess = exec(command.command);
-    commandProcess.stdout.on('data', function(data) {
-      console.log(data);
-    });
-    commandProcess.stderr.on('data', function(data) {
-      console.log(data);
-    });
-  } catch (e) {
-    console.log('Error: ' + e);
+  if (command.command != null) {
+    try {
+      execSync(command.command, { stdio: 'inherit' });
+    } catch (e) {
+      console.log('Error: ' + e);
+    }
+  } else if (command.commands != null) {
+    for (let index = 0; index < command.commands.length; index++) {
+      const singleCommand = command.commands[index];
+      try {
+        execSync(singleCommand, { stdio: 'inherit' });
+      } catch (e) {
+        console.log('Error: ' + e);
+      }
+    }
   }
 } else {
   console.log(chalk.yellow('ubolt: ' + module.exports.version));

--- a/bin/ubolt.js
+++ b/bin/ubolt.js
@@ -26,6 +26,7 @@ if (command != null) {
         execSync(singleCommand, { stdio: 'inherit' });
       } catch (e) {
         console.log('Error: ' + e);
+        break;
       }
     }
   }


### PR DESCRIPTION
Sometimes you want to run multiple commands from a single alias. Now you can! Just use  `commands:` instead of `command:` and provide an array of commands. The execution will stop if any of the commands returns a non-zero exit code.

Closes #1 