### PR TITLE
✨ Command line argument support

### DIFF
--- a/.ubolt.yaml
+++ b/.ubolt.yaml
@@ -4,6 +4,11 @@ lint:
 lint-fix:
   command: npm run lint-fix
   description: Run lint, but fix any findings
+arguments:
+  commands:
+    - ls $1
+    - ps $2
+  description: Do a test with argument replacement
 multi:
   commands:
     - sleep 1

--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ master:
 
 Note that if one of the commands fails, the execution will stop.
 
+## Command line arguments
+
+You can pass arguments to the commands by just including them after `ubolt alias`. Inside your `.ubolt.yaml` file just put `$1`, `$2`, etc. to have the arguments replaced. These
+arguments always start with `$1`. For example here would be how you specify the argument in your `.ubolt.yaml`:
+
+```
+files:
+    command: ls $1
+```
+
+And to pass it when executing:
+
+```
+ubolt files -la
+```
+
 ## Naming
 
 I wanted to make a very fast alias command executor, so why not name it after the worlds fastest man?

--- a/bin/ubolt.js
+++ b/bin/ubolt.js
@@ -15,13 +15,13 @@ const command = process.argv.length > 2 ? commands[process.argv[2]] : null;
 if (command != null) {
   if (command.command != null) {
     try {
-      execSync(command.command, { stdio: 'inherit' });
+      execSync(replaceArguments(command.command), { stdio: 'inherit' });
     } catch (e) {
       console.log('Error: ' + e);
     }
   } else if (command.commands != null) {
     for (let index = 0; index < command.commands.length; index++) {
-      const singleCommand = command.commands[index];
+      const singleCommand = replaceArguments(command.commands[index]);
       try {
         execSync(singleCommand, { stdio: 'inherit' });
       } catch (e) {
@@ -66,4 +66,19 @@ function userCommands() {
   } else {
     return {};
   }
+}
+
+/**
+ * replaceArguments
+ * @param {string} the command line
+ * @return {string} the new command line with arguments replaced
+ */
+function replaceArguments(command) {
+  let original = command;
+  let position = 1;
+  for (let index = 3; index < process.argv.length; index++) {
+    original = original.replace('$' + position.toString(), process.argv[index]);
+    position += 1;
+  }
+  return original;
 }


### PR DESCRIPTION
Now you can include command line arguments in your `command:` or `commands:` by using the convention `$1`, `$2`, etc. Then when invoking `ubolt`, just include the parameters after the alias.