### PR TITLE
🐛 fixed multiple replacement bug

### DIFF
--- a/bin/ubolt.js
+++ b/bin/ubolt.js
@@ -79,9 +79,13 @@ function userCommands() {
 function replaceArguments(command) {
   let original = command;
   let position = 1;
+  console.log('original: ' + original);
   for (let index = 3; index < process.argv.length; index++) {
-    original = original.replace('$' + position.toString(), process.argv[index]);
+    original = original
+      .split('$' + position.toString())
+      .join(process.argv[index]);
     position += 1;
   }
+  console.log('original: ' + original);
   return original;
 }


### PR DESCRIPTION
This PR fixes an issue that was causing some $# replacements to fail. Specifically if you had multiple replacements of a single parameter, only the first would be replaced.