### PR TITLE
✨ Added numberOfParams option to enforce proper number of parameters

### DIFF
--- a/.ubolt.yaml
+++ b/.ubolt.yaml
@@ -10,6 +10,8 @@ arguments:
     - ps $2
     - echo $1 $1
   description: Do a test with argument replacement
+  options:
+    numberOfParams: 2
 multi:
   commands:
     - sleep 1

--- a/bin/ubolt.js
+++ b/bin/ubolt.js
@@ -38,6 +38,9 @@ async function executeCommand() {
       command.command,
       command.options
     );
+    if (commandToExecute == null) {
+      process.exit(1);
+    }
     console.log(chalk.green(commandToExecute));
     execSync(commandToExecute, { stdio: "inherit" });
   } catch (e) {
@@ -52,6 +55,10 @@ async function executeCommands() {
       command.commands[index],
       command.options
     );
+    if (singleCommand == null) {
+      process.exit(1);
+    }
+
     try {
       console.log(chalk.green(singleCommand));
       execSync(singleCommand, { stdio: "inherit" });
@@ -95,6 +102,17 @@ function userCommands() {
  * @return {string} the new command line with arguments replaced
  */
 async function replaceArguments(command, options) {
+  if (
+    options != null &&
+    options.numberOfParams != null &&
+    options.numberOfParams != process.argv.length - 3
+  ) {
+    console.log(
+      chalk.red("Number of parameters supplied does not match expected amount")
+    );
+    return null;
+  }
+
   let original = command;
   let position = 1;
   for (let index = 3; index < process.argv.length; index++) {


### PR DESCRIPTION
This PR adds another option to the `options:` object in the command definition that allows for specifying an exact number of expected parameters. This is desirable when a command expects a single parameter to ensure that a proper command is executed instead of something unexpected.

Add `numberOfParameters: 1` for example under the `options:` in a command to enable this.

closes #18 